### PR TITLE
Add a hide_url option to suppress URLs in login item subtext

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ From then on, `1p` will show your items. ↵ opens the website in your browser (
 
 ![](https://user-images.githubusercontent.com/1699443/166268538-3706cc02-dd9e-4a05-8b4f-4eadca4cf692.png)
 
-The Workflow will attempt to detect when you update items in 1Password and present you with the option to refresh them. You can disable this behaviour by flipping the `auto_refresh` Workflow Environment Variable to `0`. Set `logins_only` to `1` if you want to hide other item types.
+The Workflow will attempt to detect when you update items in 1Password and present you with the option to refresh them. You can disable this behaviour by flipping the `auto_refresh` Workflow Environment Variable to `0`. Set `logins_only` to `1` if you want to hide other item types. Set `hide_url` to `1` if you want to hide URLs in the subtext of logins.
 
 Uncommon but useful actions, such as toggling vaults, can be accessed via `:1pextras`.
 

--- a/Workflow/1password.js
+++ b/Workflow/1password.js
@@ -63,7 +63,9 @@ function getItems(userID, excludedVaults) {
     return {
       uid: item["id"],
       title: item["title"],
-      subtitle: url ? `${url} 𐄁 ${vaultName} 𐄁 ${accountURL}` : `${vaultName} 𐄁 ${accountURL}`,
+      subtitle: (url && envVar("hide_url") !== "1") 
+        ? `${url} 𐄁 ${vaultName} 𐄁 ${accountURL}` 
+        : `${vaultName} 𐄁 ${accountURL}`,
       variables: {
         accountID: accountID,
         vaultID: vaultID,

--- a/Workflow/info.plist
+++ b/Workflow/info.plist
@@ -1214,6 +1214,7 @@ printf '#!/bin/zsh\n' &gt; "${script}"
 printf 'clear\n' &gt;&gt; "${script}"
 printf 'export alfred_workflow_data=%q\n' "${alfred_workflow_data}" &gt;&gt; "${script}"
 printf 'export logins_only=%q\n' "${logins_only}" &gt;&gt; "${script}"
+printf 'export hide_url=%q\n' "${hide_url}" &gt;&gt; "${script}"
 printf '%q/signin.zsh\n' "${PWD}" &gt;&gt; "${script}"
 printf 'rm "${0}"\n' &gt;&gt; "${script}"
 
@@ -1738,7 +1739,7 @@ From then on, `1p` will show your items. ↵ opens the website in your browser (
 
 ![](https://user-images.githubusercontent.com/1699443/166268538-3706cc02-dd9e-4a05-8b4f-4eadca4cf692.png)
 
-The Workflow will attempt to detect when you update items in 1Password and present you with the option to refresh them. You can disable this behaviour by flipping the `auto_refresh` Workflow Environment Variable to `0`. Set `logins_only` to `1` if you want to hide other item types.
+The Workflow will attempt to detect when you update items in 1Password and present you with the option to refresh them. You can disable this behaviour by flipping the `auto_refresh` Workflow Environment Variable to `0`. Set `logins_only` to `1` if you want to hide other item types. Set `hide_url` to `1` if you want to hide URLs in the subtext of logins.
 
 Uncommon but useful actions, such as toggling vaults, can be accessed via `:1pextras`.
 


### PR DESCRIPTION
Allow for a bit of a terser view of login items by giving the option to exclude URLs from results