### PR TITLE
Support items with URLs that lack a scheme

### DIFF
--- a/Workflow/info.plist
+++ b/Workflow/info.plist
@@ -1420,8 +1420,10 @@ echo '{ "items": [{
   const itemID = $.NSProcessInfo.processInfo.environment.objectForKey("itemID").js
   const query = itemID + "=" + itemID
 
-  const url = $.NSProcessInfo.processInfo.environment.objectForKey("url").js
+  let url = $.NSProcessInfo.processInfo.environment.objectForKey("url").js
   const urlObject = $.NSURL.URLWithString(url)
+
+  if (urlObject.scheme.js === undefined) url = "https://" + url
 
   if (urlObject.query.js === undefined) return url + "?" + query
   return url + "&amp;" + query

--- a/Workflow/info.plist
+++ b/Workflow/info.plist
@@ -1420,10 +1420,9 @@ echo '{ "items": [{
   const itemID = $.NSProcessInfo.processInfo.environment.objectForKey("itemID").js
   const query = itemID + "=" + itemID
 
-  let url = $.NSProcessInfo.processInfo.environment.objectForKey("url").js
-  const urlObject = $.NSURL.URLWithString(url)
-
-  if (urlObject.scheme.js === undefined) url = "https://" + url
+  const initURL = $.NSProcessInfo.processInfo.environment.objectForKey("url").js
+  const urlObject = $.NSURL.URLWithString(initURL)
+  const url = (urlObject.scheme.js === undefined) ? "https://" + url : url
 
   if (urlObject.query.js === undefined) return url + "?" + query
   return url + "&amp;" + query


### PR DESCRIPTION
Default scheme-less items to https:// when opening them

Otherwise you get a very unhelpful error from Alfred:
<img width="372" alt="Screen Shot 2022-05-09 at 11 01 37" src="https://user-images.githubusercontent.com/41373/167469957-5f4b2601-eea0-4a75-86e9-14db885d0575.png">

