### PR TITLE
Swap shortcuts for username & password

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Interact with your 1Password items via the `1p` keyword.
 
 ![Alfred search for 1p](Workflow/images/about/1p.png)
 
-* <kbd>↩&#xFE0E;</kbd>: Open and Fill.
-* <kbd>⌘</kbd><kbd>↩&#xFE0E;</kbd>: View in 1Password.
-* <kbd>⌥</kbd><kbd>↩&#xFE0E;</kbd>: Copy Password.
-* <kbd>⌃</kbd><kbd>↩&#xFE0E;</kbd>: Copy Username.
-* <kbd>⇧</kbd><kbd>↩&#xFE0E;</kbd>: Copy One-Time Password
+- <kbd>↩&#xFE0E;</kbd>: Open and Fill.
+- <kbd>⌘</kbd><kbd>↩&#xFE0E;</kbd>: View in 1Password.
+- <kbd>⌃</kbd><kbd>↩&#xFE0E;</kbd>: Copy Password.
+- <kbd>⌥</kbd><kbd>↩&#xFE0E;</kbd>: Copy Username.
+- <kbd>⇧</kbd><kbd>↩&#xFE0E;</kbd>: Copy One-Time Password
 
 Uncommon but useful actions, such as toggling vaults, can be accessed with `:1pextras`.
 


### PR DESCRIPTION
The shortcuts for "Copy username" & "Copy password" are not correct in the README. This PR aligns them with the latest functionality of the workflow.